### PR TITLE
Change tag iteration, as tags is now sent as a list of dicts to workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+tag_regex = "^refs/pull/(\\d+)/merge$"
 
 [tool.setuptools]
 packages = ["story_clustering"]

--- a/story_clustering/clustering.py
+++ b/story_clustering/clustering.py
@@ -77,7 +77,8 @@ class Cluster(Predictor):
                 keywords = {}
                 if len(story["tags"]) < 5:
                     continue
-                for tag, tag_type in story["tags"].items():
+                for tag_dict in story["tags"]:
+                    tag, tag_type = tag_dict.values()
                     if (tag not in doc.content) and (tag.lower() not in doc.content):
                         continue
                     baseform = replace_umlauts_with_digraphs(tag)

--- a/story_clustering/clustering.py
+++ b/story_clustering/clustering.py
@@ -142,20 +142,20 @@ class Cluster(Predictor):
         graph = KeywordGraph(story_id=cluster["id"])
         # as text we use for now the content of first item
         graph.text = cluster["news_items"][0]["content"]
-        tags = cluster["tags"]
+        tag_names = [tag_dict.get("name") for tag_dict in cluster.get("tags", [])]
 
         # update corpus DF for each of the tags
         # use corpus.DF[baseform] to update the df of each keyword
-        for keyword_1 in tags.keys():
+        for keyword_1 in tag_names:
             baseform1 = replace_umlauts_with_digraphs(keyword_1)
             if baseform1 in corpus.DF:
                 corpus.DF[baseform1] += self.compute_df(keyword_1, cluster["news_items"])
             else:
                 corpus.DF[baseform1] = self.compute_df(keyword_1, cluster["news_items"])
 
-        for keyword_1 in tags.keys():
+        for keyword_1 in tag_names:
             baseform1 = replace_umlauts_with_digraphs(keyword_1)
-            for keyword_2 in tags.keys():
+            for keyword_2 in tag_names:
                 if keyword_1 != keyword_2:
                     baseform2 = replace_umlauts_with_digraphs(keyword_2)
 
@@ -187,7 +187,8 @@ class Cluster(Predictor):
         super_cluster_id = None
         for cluster in already_clustered_events:
             existing_keywords = []
-            for tag in cluster["tags"].keys():
+            tag_names = [tag_dict.get("name") for tag_dict in cluster.get("tags", [])]
+            for tag in tag_names:
                 baseform = replace_umlauts_with_digraphs(tag)
                 existing_keywords.append(baseform)
             if find_keywords_matches(keywords_new_cluster, existing_keywords) > POLYFUZZ_THRESHOLD:
@@ -232,9 +233,9 @@ class Cluster(Predictor):
 
         # add to g the new nodes and edges from already_clusterd_events
         for cluster in already_clustered_events:
-            tags = cluster["tags"]
-            for keyword_1 in tags.keys():
-                for keyword_2 in tags.keys():
+            tag_names = [tag_dict.get("name") for tag_dict in cluster.get("tags", [])]
+            for keyword_1 in tag_names:
+                for keyword_2 in tag_names:
                     if keyword_1 != keyword_2:
                         # doc frequency is the number of documents in the cluster
                         df = len(cluster["news_items"])

--- a/story_clustering/tests/testdata.py
+++ b/story_clustering/tests/testdata.py
@@ -331,6 +331,17 @@ def merge_multiple(base_dict: dict, update_dicts: list[dict]):
     return merged_dicts
 
 
+def transform_stories(story_list: list) -> list[dict]:
+    # transform the tags of each story to a list of dicts
+    transformed_stories = []
+
+    for story in story_list:
+        transformed_story = copy.deepcopy(story)
+        transformed_story["tags"] = [{"name": key, "tag_type": value} for key, value in story["tags"].items()]
+        transformed_stories.append(transformed_story)
+    return transformed_stories
+
+
 def cluster_news_items(storys: list[dict]):
     base_story = copy.deepcopy(storys[0])
     for story in storys[1:]:
@@ -338,38 +349,42 @@ def cluster_news_items(storys: list[dict]):
     return base_story
 
 
-news_item_list = merge_multiple(
-    base_story,
-    [
-        story_1,
-        story_2,
-        story_3,
-        story_4,
-        story_5,
-        story_6,
-        story_7,
-        story_8,
-        story_9,
-        story_10,
-    ],
+news_item_list = transform_stories(
+    merge_multiple(
+        base_story,
+        [
+            story_1,
+            story_2,
+            story_3,
+            story_4,
+            story_5,
+            story_6,
+            story_7,
+            story_8,
+            story_9,
+            story_10,
+        ],
+    )
 )
 
-clustered_news_item_list = merge_multiple(
-    base_story,
-    [
-        cluster_news_items([story_4, story_7]),
-        cluster_news_items([story_7, story_9, story_10]),
-        story_1,
-        story_2,
-        story_3,
-    ],
+clustered_news_item_list = transform_stories(
+    merge_multiple(
+        base_story,
+        [
+            cluster_news_items([story_4, story_7]),
+            cluster_news_items([story_7, story_9, story_10]),
+            story_1,
+            story_2,
+            story_3,
+        ],
+    )
 )
 
-news_item_tags_1 = {"Cyber": "CySec"}
-news_item_tags_2 = {"Security": "Misc"}
-news_item_tags_3 = {"New Orleans": "LOC"}
-news_item_tags_4 = {"CVE": "CySec"}
-news_item_tags_5 = {"CVE-2021-1234": "CVE"}
+news_item_tags_1 = [{"name": "Cyber", "tag_type": "CySec"}]
+news_item_tags_2 = [{"name": "Security", "tag_type": "Misc"}]
+news_item_tags_3 = [{"name": "New Orleans", "tag_type": "LOC"}]
+news_item_tags_4 = [{"name": "CVE", "tag_type": "CySec"}]
+news_item_tags_5 = [{"name": "CVE-2021-1234", "tag_type": "CVE"}]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The data type of "tags", returned by the Story.to_worker_dict changed from {"<tag_name>": "<tag_type>"} -> [{"name": "<tag_name>", "tag_type": "<tag_type>"}, ...] recently

- Change iteration over tags in create_corpus, create_keygraph, merge_cluster and incremental_clustering
- Change tag data types in test data