### PR TITLE
Add clustering message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,15 @@ dev = ["pytest", "ruff"]
 
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=61",
     "setuptools_scm[toml]>=6.2",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-tag_regex = "^refs/pull/(\\d+)/merge$"
+fallback_version = "0.0.0"
+tag_regex = "^(?:refs/pull/(\\d+)/merge|(?P<version>\\d+\\.\\d+\\.\\d+))$"
 
 [tool.setuptools]
 packages = ["story_clustering"]

--- a/story_clustering/router.py
+++ b/story_clustering/router.py
@@ -20,13 +20,15 @@ class Clustering(MethodView):
 
         if all(len(story["news_items"]) == 1 for story in stories):
             clustering_results = self.processor.initial_clustering(stories)
-            logger.info(f"Initial Clustering done with: {len(stories)} news items")
-            return jsonify({"cluster_ids": clustering_results})
+            msg = f"Initial Clustering done with: {len(stories)} news items"
+            logger.info(msg)
+            return jsonify({"cluster_ids": clustering_results, "message": msg})
 
         already_clustered, to_cluster = separate_stories(stories)
         clustering_results = self.processor.incremental_clustering_v2(to_cluster, already_clustered)
-        logger.info(f"incremental Clustering done with: {len(stories)} news items")
-        return jsonify({"cluster_ids": clustering_results})
+        msg = f"incremental Clustering done with: {len(stories)} news items"
+        logger.info(msg)
+        return jsonify({"cluster_ids": clustering_results, "message": msg})
 
 
 class HealthCheck(MethodView):


### PR DESCRIPTION
Taranis used a static message when running the story clustering bot as of now: https://github.com/taranis-ai/taranis-ai/blob/a32f98e4f04f79ab2b4026231235b10b29932e50/src/worker/worker/bots/story_bot.py#L28

Send the info if initial or incremental clustering directly.

Also extend the setuptools_scm tag_regex so that uv does not fail if tags exist in the git repo