### PR TITLE
Fix Story tag format

### DIFF
--- a/story_clustering/clustering.py
+++ b/story_clustering/clustering.py
@@ -55,9 +55,9 @@ class Cluster(Predictor):
         """Creates a Corpus object from a JSON object denoting all documents
 
         Args:
-            new_news_items (list[dict]): list of dict with following keys
+            new_stories (list[dict]): list of dict with following keys
                 {'id': str, 'link': str, 'text': str, 'title':str,'date': 'YYYY-MM-DD', 'lang': str,
-                'tags': [{'name': str, 'tag_type': str}]}
+                'tags': {"<tag_name>": {"name": "<tag_name>", "tag_type": "<tag_type>"}, ...}
         Returns:
             corpus: Corpus of documents
         """
@@ -77,8 +77,8 @@ class Cluster(Predictor):
                 keywords = {}
                 if len(story["tags"]) < 5:
                     continue
-                for tag_dict in story["tags"]:
-                    tag, tag_type = tag_dict.values()
+                for tag, tag_dict in story["tags"].items():
+                    tag_type = tag_dict.get("tag_type", "")
                     if (tag not in doc.content) and (tag.lower() not in doc.content):
                         continue
                     baseform = replace_umlauts_with_digraphs(tag)
@@ -142,7 +142,7 @@ class Cluster(Predictor):
         graph = KeywordGraph(story_id=cluster["id"])
         # as text we use for now the content of first item
         graph.text = cluster["news_items"][0]["content"]
-        tag_names = [tag_dict.get("name") for tag_dict in cluster.get("tags", [])]
+        tag_names = list(cluster.get("tags", {}).keys())
 
         # update corpus DF for each of the tags
         # use corpus.DF[baseform] to update the df of each keyword
@@ -187,7 +187,7 @@ class Cluster(Predictor):
         super_cluster_id = None
         for cluster in already_clustered_events:
             existing_keywords = []
-            tag_names = [tag_dict.get("name") for tag_dict in cluster.get("tags", [])]
+            tag_names = list(cluster.get("tags", {}).keys())
             for tag in tag_names:
                 baseform = replace_umlauts_with_digraphs(tag)
                 existing_keywords.append(baseform)
@@ -233,7 +233,7 @@ class Cluster(Predictor):
 
         # add to g the new nodes and edges from already_clusterd_events
         for cluster in already_clustered_events:
-            tag_names = [tag_dict.get("name") for tag_dict in cluster.get("tags", [])]
+            tag_names = list(cluster.get("tags", {}).keys())
             for keyword_1 in tag_names:
                 for keyword_2 in tag_names:
                     if keyword_1 != keyword_2:

--- a/story_clustering/tests/testdata.py
+++ b/story_clustering/tests/testdata.py
@@ -337,7 +337,7 @@ def transform_stories(story_list: list) -> list[dict]:
 
     for story in story_list:
         transformed_story = copy.deepcopy(story)
-        transformed_story["tags"] = [{"name": key, "tag_type": value} for key, value in story["tags"].items()]
+        transformed_story["tags"] = {key: {"name": key, "tag_type": value} for key, value in story["tags"].items()}
         transformed_stories.append(transformed_story)
     return transformed_stories
 
@@ -380,11 +380,11 @@ clustered_news_item_list = transform_stories(
     )
 )
 
-news_item_tags_1 = [{"name": "Cyber", "tag_type": "CySec"}]
-news_item_tags_2 = [{"name": "Security", "tag_type": "Misc"}]
-news_item_tags_3 = [{"name": "New Orleans", "tag_type": "LOC"}]
-news_item_tags_4 = [{"name": "CVE", "tag_type": "CySec"}]
-news_item_tags_5 = [{"name": "CVE-2021-1234", "tag_type": "CVE"}]
+news_item_tags_1 = {"Cyber": {"name": "Cyber", "tag_type": "CySec"}}
+news_item_tags_2 = {"Security": {"name": "Security", "tag_type": "Misc"}}
+news_item_tags_3 = {"New Orleans": {"name": "New Orleans", "tag_type": "LOC"}}
+news_item_tags_4 = {"CVE": {"name": "CVE", "tag_type": "CySec"}}
+news_item_tags_5 = {"CVE-2021-1234": {"name": "CVE-2021-1234", "tag_type": "CVE"}}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In PR https://github.com/taranis-ai/taranis-ai/pull/526, the tag format was changed to 

```python
  {"<tag_name>": {"name": "<tag_name>", "tag_type": "<tag_type>"} 
```

Adapt clustering code accordingly